### PR TITLE
一些小的修复和调整

### DIFF
--- a/src/bili_api/music.py
+++ b/src/bili_api/music.py
@@ -127,23 +127,25 @@ def run_music_download(index: int, search_list: SongList, file_type: str = "mp3"
     logger.info(f"  title: {title}")
     logger.info(f"  输出文件: {output_file}")
 
-    # 如果文件存在，弹出提示窗口
+    # 如果文件存在，执行覆盖操作
     if output_file.exists():
-        w = MessageBox(
-            "文件已存在",
-            f"文件 '{output_file.relative_to(MAIN_PATH)}' 已存在。是否覆盖？",
-            app_context.main_window,
+        logger.info(f"文件 {output_file} 已存在，执行覆盖操作。")
+
+    try:
+        sync(download_music(bv, output_file))
+        return True
+    except Exception:
+        logger.exception(f"下载失败: {bv}")
+        InfoBar.error(
+            title="错误",
+            content=f"下载失败: {title}",
+            orient=Qt.Orientation.Horizontal,
+            isClosable=True,
+            position=InfoBarPosition.TOP,
+            duration=3000,
+            parent=app_context.main_window,
         )
-
-        w.setClosableOnMaskClicked(True)
-        w.setDraggable(True)
-
-        if not w.exec():
-            logger.info("用户取消下载。")
-            return False
-
-    sync(download_music(bv, output_file))
-    return True
+        return False
 
 
 def _get_video_title_by_bvid(bvid: str) -> str:

--- a/src/bili_api/music.py
+++ b/src/bili_api/music.py
@@ -3,7 +3,6 @@ import subprocess
 import uuid
 from pathlib import Path
 
-from PyQt6.QtCore import Qt
 from bilibili_api import HEADERS, get_client, sync, video
 from loguru import logger
 from qfluentwidgets import InfoBar, InfoBarPosition, MessageBox

--- a/src/bili_api/music.py
+++ b/src/bili_api/music.py
@@ -108,14 +108,7 @@ def run_music_download(index: int, search_list: SongList, file_type: str = "mp3"
     """运行下载器"""
     info = search_list.select_info(index)
     if info is None:
-        InfoBar.error(
-            "错误",
-            "索引超出范围或信息不存在",
-            orient=Qt.Orientation.Horizontal,
-            position=InfoBarPosition.TOP_RIGHT,
-            duration=1500,
-            parent=app_context.main_window,
-        )
+        logger.error("索引超出范围或信息不存在")
         return False
 
     bv = info["bv"]
@@ -136,15 +129,6 @@ def run_music_download(index: int, search_list: SongList, file_type: str = "mp3"
         return True
     except Exception:
         logger.exception(f"下载失败: {bv}")
-        InfoBar.error(
-            title="错误",
-            content=f"下载失败: {title}",
-            orient=Qt.Orientation.Horizontal,
-            isClosable=True,
-            position=InfoBarPosition.TOP,
-            duration=3000,
-            parent=app_context.main_window,
-        )
         return False
 
 

--- a/src/ui/interface/search.py
+++ b/src/ui/interface/search.py
@@ -115,6 +115,7 @@ class SearchInterface(QWidget):
             self.loading.close()
             self.loading = None
         self.main_window.setEnabled(True)
+        self.DownloadBtn.setEnabled(True)
 
         if success:
             InfoBar.success(
@@ -126,7 +127,16 @@ class SearchInterface(QWidget):
                 duration=2000,
                 parent=self,
             )
-        # 如果下载失败，run_music_download 会自己记录日志和显示错误 InfoBar
+        else:
+            InfoBar.error(
+                title="错误",
+                content="下载失败，请检查网络与日志",
+                orient=Qt.Orientation.Horizontal,
+                isClosable=True,
+                position=InfoBarPosition.TOP,
+                duration=3000,
+                parent=self,
+            )
 
     def getVideo_btn(self):
         """获取歌曲列表按钮功能实现"""
@@ -335,6 +345,7 @@ class SearchInterface(QWidget):
 
         # 显示加载动画并禁用主窗口
         self.loading = showLoading(self.DownloadBtn)
+        self.DownloadBtn.setEnabled(False)
         self.main_window.setEnabled(False)
 
         # 创建并启动下载线程

--- a/src/ui/interface/search.py
+++ b/src/ui/interface/search.py
@@ -349,6 +349,6 @@ class SearchInterface(QWidget):
         self.main_window.setEnabled(False)
 
         # 创建并启动下载线程
-        self._download_thread = SimpleThread(lambda: run_music_download(index, self.search_result, fileType))
+        self._download_thread = SimpleThread(lambda idx=index, sr=self.search_result, ft=fileType: run_music_download(idx, sr, ft))
         self._download_thread.task_finished.connect(self.on_download_finished)
         self._download_thread.start()

--- a/uv.lock
+++ b/uv.lock
@@ -408,7 +408,7 @@ wheels = [
 
 [[package]]
 name = "neurosangspider"
-version = "1.1.4"
+version = "1.2.0"
 source = { virtual = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
感谢作者的付出，非常好项目使我cookie旋转。
这些是修改内容：
refactor(ui): 在下载歌曲时添加与获取歌曲列表相似的加载动画，并在新线程中执行下载，避免主 UI 线程冻结；将“覆盖已存在文件”的确认对话框移动到主线程显示，避免在非主线程弹窗导致的程序闪退（在macos上复现）；搜索框增加了placeholder
fix(ui): 将下载失败的提示也移动到主线程弹出