### PR TITLE
feat(ui)下载歌曲完成后自动跳转到本地播放器

### DIFF
--- a/.idea/misc.xml
+++ b/.idea/misc.xml
@@ -3,5 +3,5 @@
   <component name="Black">
     <option name="sdkName" value="uv (neuroSongSpider)" />
   </component>
-  <component name="ProjectRootManager" version="2" project-jdk-name="uv (neuroSongSpider)" project-jdk-type="Python SDK" />
+  <component name="ProjectRootManager" version="2" project-jdk-name="Python 3.13" project-jdk-type="Python SDK" />
 </project>

--- a/.idea/neuroSongSpider.iml
+++ b/.idea/neuroSongSpider.iml
@@ -13,7 +13,7 @@
       <excludeFolder url="file://$MODULE_DIR$/build" />
       <excludeFolder url="file://$MODULE_DIR$/dist" />
     </content>
-    <orderEntry type="jdk" jdkName="uv (neuroSongSpider)" jdkType="Python SDK" />
+    <orderEntry type="jdk" jdkName="Python 3.13" jdkType="Python SDK" />
     <orderEntry type="sourceFolder" forTests="false" />
   </component>
   <component name="PyDocumentationSettings">

--- a/src/assets/i18n/en_US.properties
+++ b/src/assets/i18n/en_US.properties
@@ -231,3 +231,7 @@ nav.search=Search
 nav.play_queue=Play Queue
 nav.local_player=Local Player
 nav.settings=Settings
+
+settings.auto_switch_playlist_title=Auto Switch to Playlist
+settings.auto_switch_playlist_desc=Automatically switch to the playlist after downloading a song
+settings.auto_switch_playlist_to=Auto switch to playlist {status}

--- a/src/assets/i18n/zh_CN.properties
+++ b/src/assets/i18n/zh_CN.properties
@@ -231,3 +231,7 @@ nav.search=搜索
 nav.play_queue=播放列表
 nav.local_player=本地播放
 nav.settings=设置
+
+settings.auto_switch_playlist_title=下载后自动跳转
+settings.auto_switch_playlist_desc=下载歌曲完成后自动跳转到播放列表
+settings.auto_switch_playlist_to=已{status}下载后自动跳转功能

--- a/src/config.py
+++ b/src/config.py
@@ -91,6 +91,9 @@ class Config(QConfig):
     enable_cover = ConfigItem("Appearance", "EnableCover", True)
     cover_corner_radius = ConfigItem("Appearance", "CoverCornerRadius", 10)
 
+    # 是否在下载完成后自动跳转到播放列表并聚焦
+    auto_switch_playlist = ConfigItem("AutoSwitchPlaylist", "EnableAutoSwitchPlaylist", False)
+
     # 亚克力背景设置（主页正在播放卡片使用）
     acrylic_enabled = ConfigItem("Appearance", "AcrylicEnabled", True)
     acrylic_blur_radius = ConfigItem("Appearance", "AcrylicBlurRadius", 3)

--- a/src/ui/interface/local_player.py
+++ b/src/ui/interface/local_player.py
@@ -242,6 +242,26 @@ class LocalPlayerInterface(QWidget):
         except Exception:
             logger.exception("加载本地歌曲失败")
 
+    def select_and_highlight_song(self, filename: str):
+        """在本地播放器中选中并高亮显示指定文件名的歌曲"""
+        try:
+            # 遍历所有行查找匹配的文件名
+            for row in range(self.tableView.rowCount()):
+                item = self.tableView.item(row, self._name_col())
+                if item and item.data(Qt.ItemDataRole.UserRole) == filename:
+                    # 选中该行
+                    self.tableView.selectRow(row)
+                    # 滚动到该行
+                    self.tableView.scrollToItem(item, QAbstractItemView.ScrollHint.PositionAtCenter)
+                    logger.info(f"已在本地播放器中选中歌曲: {filename}")
+                    return True
+            
+            logger.warning(f"未在本地播放器中找到歌曲: {filename}")
+            return False
+        except Exception as e:
+            logger.exception(f"选中歌曲时出错: {e}")
+            return False
+
     def play_selected_song(self, row, column=None):
         """双击播放指定行的歌曲
 

--- a/src/ui/interface/search.py
+++ b/src/ui/interface/search.py
@@ -176,6 +176,10 @@ class SearchInterface(QWidget):
                 duration=2000,
                 parent=self,
             )
+
+            if cfg.auto_switch_playlist.value:
+                    self.switch_to_playlist()
+
         else:
             InfoBar.error(
                 title=t("common.error"),
@@ -398,6 +402,23 @@ class SearchInterface(QWidget):
         except Exception:
             logger.exception("计算自适应标题宽度失败")
             return 0
+
+    def switch_to_playlist(self):
+        # 获取刚下载的歌曲信息
+        index = self.tableView.currentRow()
+        if index >= 0:
+            info = self.search_result.select_info(index)
+            if info:
+                fileType = cfg.download_type.value
+                title = fix_filename(info["title"]).replace(" ", "").replace("_", "", 1)
+                downloaded_file_name = f"{title}.{fileType}"
+
+                # 切换到本地播放器界面
+                self.main_window.switchTo(self.main_window.localPlayerInterface)
+
+                # 延迟执行选中歌曲的操作，确保界面已加载完成
+                QTimer.singleShot(100, lambda: self.main_window.localPlayerInterface.select_and_highlight_song(
+                    downloaded_file_name))
 
     def writeList(self):
         """将搜索结果写入表格"""

--- a/src/ui/interface/settings/card.py
+++ b/src/ui/interface/settings/card.py
@@ -193,6 +193,11 @@ class SettingsCard(GroupHeaderCardWidget):
         self.playerBarSwitch.setChecked(cfg.enable_player_bar.value)
         self.playerBarSwitch.checkedChanged.connect(self.on_player_bar_switch_changed)
 
+        # 下载后自动聚焦到歌曲列表
+        self.autoSwitchPlaylistSwitch = SwitchButton(parent=self)
+        self.autoSwitchPlaylistSwitch.setChecked(cfg.auto_switch_playlist.value)
+        self.autoSwitchPlaylistSwitch.checkedChanged.connect(self.on_auto_switch_playlist_changed)
+
         # 封面显示开关
         self.coverSwitch = SwitchButton(parent=self)
         self.coverSwitch.setChecked(cfg.enable_cover.value)
@@ -252,6 +257,12 @@ class SettingsCard(GroupHeaderCardWidget):
             t("settings.player_bar"),
             t("settings.player_bar_desc"),
             self.playerBarSwitch,
+        )
+        self.addGroup(
+            FluentIcon.LINK,
+            t("settings.auto_switch_playlist_title"),
+            t("settings.auto_switch_playlist_desc"),
+            self.autoSwitchPlaylistSwitch,
         )
         self.addGroup(
             FluentIcon.BRUSH,
@@ -322,6 +333,17 @@ class SettingsCard(GroupHeaderCardWidget):
         InfoBar.success(
             t("common.settings_success"),
             t("common.player_bar_set", display_mode=t("common.enabled") if checked else t("common.disabled")),
+            parent=app_context.main_window,
+            position=InfoBarPosition.BOTTOM_RIGHT,
+            duration=1500,
+        )
+
+    def on_auto_switch_playlist_changed(self, checked: bool) -> None:
+        cfg.auto_switch_playlist.value = checked
+        cfg.save()
+        InfoBar.success(
+            t("common.settings_success"),
+            t("settings.auto_switch_playlist_to", status=t("common.enabled") if checked else t("common.disabled")),
             parent=app_context.main_window,
             position=InfoBarPosition.BOTTOM_RIGHT,
             duration=1500,

--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -72,7 +72,7 @@ class MainWindow(FluentWindow):
         QApplication.processEvents()  # 让启动画面动画有机会播放
 
         self.addSubInterface(
-            interface=SearchInterface(self, main_window=self),
+            interface=self.searchInterface,
             icon=FIF.SEARCH,
             text=t("nav.search"),
             position=NavigationItemPosition.TOP,
@@ -80,7 +80,7 @@ class MainWindow(FluentWindow):
         QApplication.processEvents()  # 让启动画面动画有机会播放
 
         self.addSubInterface(
-            interface=PlayQueueInterface(self, main_window=self),
+            interface=self.playQueueInterface,
             icon=FIF.ALIGNMENT,
             text=t("nav.play_queue"),
             position=NavigationItemPosition.TOP,
@@ -88,7 +88,7 @@ class MainWindow(FluentWindow):
         QApplication.processEvents()  # 让启动画面动画有机会播放
 
         self.addSubInterface(
-            interface=LocalPlayerInterface(self, main_window=self),
+            interface=self.localPlayerInterface,
             icon=FIF.PLAY,
             text=t("nav.local_player"),
             position=NavigationItemPosition.BOTTOM,
@@ -96,7 +96,7 @@ class MainWindow(FluentWindow):
         QApplication.processEvents()  # 让启动画面动画有机会播放
 
         self.addSubInterface(
-            interface=SettingInterface(self),
+            interface=self.settingInterface,
             icon=FIF.SETTING,
             text=t("nav.settings"),
             position=NavigationItemPosition.BOTTOM,


### PR DESCRIPTION
现在下载一首歌曲完成后，可以直接跳转到本地播放器，并使歌曲列表聚焦在该歌曲上