### PR TITLE
fix(ui): 优化确认退出对话框的样式

### DIFF
--- a/src/ui/main_window.py
+++ b/src/ui/main_window.py
@@ -41,11 +41,13 @@ class CloseActionDialog(MessageBoxBase):
         self.setWindowTitle(t("dialog.close_choice.title"))
 
         self.setMinimumWidth(300)
-        self.viewLayout.setContentsMargins(55, 40, 0, 20)
+        self.viewLayout.setContentsMargins(55, 35, 0, 20)
         self.viewLayout.setSpacing(12)
 
         self.titleLabel = SubtitleLabel(t("dialog.close_choice.title"), self)
         self.viewLayout.addWidget(self.titleLabel)
+
+        self.viewLayout.addSpacing(6)
 
         # 选项：最小化/退出（单选）
         self._buttonGroup = QButtonGroup(self)
@@ -63,7 +65,6 @@ class CloseActionDialog(MessageBoxBase):
         self.viewLayout.addWidget(self.minimizeRadio)
         self.viewLayout.addWidget(self.exitRadio)
 
-        # 不再提示复选框
         self.viewLayout.addSpacing(12)
 
         self.checkBox = CheckBox(t("dialog.close_choice.always_minimize"), self)


### PR DESCRIPTION

<img width="1088" height="688" alt="PixPin_2026-01-14_20-08-35" src="https://github.com/user-attachments/assets/11f75909-c214-41ef-ab77-de172a2f6806" />

